### PR TITLE
Fix XML parsing vulnerability

### DIFF
--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/FunctionDatabase.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/FunctionDatabase.java
@@ -377,8 +377,9 @@ public interface FunctionDatabase extends AutoCloseable {
 	}
 
 	/**
-	 * Determines if a given xml file is a config template. This is done by opening the file
-	 * and checking for the presence of a {@code <dbconfig>} root tag.
+     * Determines if a given xml file is a config template. This method parses the XML
+     * in a secure manner (external entities and DTDs are disabled) and checks for the
+     * presence of a {@code <dbconfig>} root tag.
 	 * 
 	 * @param file the file to inspect
 	 * @return true if the file is config template

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/FunctionDatabase.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/FunctionDatabase.java
@@ -19,6 +19,7 @@ import java.io.*;
 import java.util.*;
 
 import javax.xml.parsers.*;
+import javax.xml.XMLConstants;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -383,9 +384,16 @@ public interface FunctionDatabase extends AutoCloseable {
 	static boolean isConfigTemplate(File file) {
 
 		try {
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder builder = factory.newDocumentBuilder();
-			Document doc = builder.parse(file);
+                       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                       factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                       factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                       factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                       factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                       factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                       factory.setXIncludeAware(false);
+                       factory.setExpandEntityReferences(false);
+                       DocumentBuilder builder = factory.newDocumentBuilder();
+                       Document doc = builder.parse(file);
 
 			Element rootElem = doc.getDocumentElement();
 			if (rootElem.getTagName().equals("dbconfig")) {

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/FunctionDatabase.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/FunctionDatabase.java
@@ -21,6 +21,8 @@ import java.util.*;
 import javax.xml.parsers.*;
 import javax.xml.XMLConstants;
 
+import ghidra.util.xml.XmlUtilities;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
@@ -385,11 +387,13 @@ public interface FunctionDatabase extends AutoCloseable {
 
 		try {
                        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-                       factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
-                       factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-                       factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-                       factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                       factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                       factory.setFeature(XmlUtilities.FEATURE_DISALLOW_DTD, true);
+                       factory.setFeature(XmlUtilities.FEATURE_EXTERNAL_GENERAL_ENTITIES, false);
+                       factory.setFeature(XmlUtilities.FEATURE_EXTERNAL_PARAMETER_ENTITIES, false);
                        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                       factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                       factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
                        factory.setXIncludeAware(false);
                        factory.setExpandEntityReferences(false);
                        DocumentBuilder builder = factory.newDocumentBuilder();

--- a/Ghidra/Features/BSim/src/test/java/ghidra/features/bsim/query/FunctionDatabaseSecurityTest.java
+++ b/Ghidra/Features/BSim/src/test/java/ghidra/features/bsim/query/FunctionDatabaseSecurityTest.java
@@ -1,0 +1,42 @@
+package ghidra.features.bsim.query;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import generic.test.AbstractGTest;
+
+/**
+ * Tests demonstrating the XXE vulnerability in {@link FunctionDatabase#isConfigTemplate}
+ * and verifying it is now mitigated.
+ */
+public class FunctionDatabaseSecurityTest extends AbstractGTest {
+
+    @Test
+    public void testIsConfigTemplateRejectsExternalEntity() throws Exception {
+        File dir = new File(getTestDirectoryPath());
+        File secret = new File(dir, "secret.txt");
+        Files.write(secret.toPath(), "SECRET".getBytes());
+
+        String xml = "<!DOCTYPE dbconfig [<!ENTITY xxe SYSTEM '" + secret.toURI().toString() + "'>]>" +
+                      "<dbconfig>&xxe;</dbconfig>";
+        File xmlFile = new File(dir, "malicious.xml");
+        Files.write(xmlFile.toPath(), xml.getBytes());
+
+        // Simulate old vulnerable parser
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(xmlFile);
+        assertEquals("SECRET", doc.getDocumentElement().getTextContent().trim());
+
+        // Current implementation should not resolve external entities
+        boolean result = FunctionDatabase.isConfigTemplate(xmlFile);
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add secure XML parsing features to `FunctionDatabase.isConfigTemplate`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ed5e9935883259ec8951481b0d52d